### PR TITLE
Replaces backup DNS server with Google's 8.8.4.4

### DIFF
--- a/config-files/udhcpd.conf
+++ b/config-files/udhcpd.conf
@@ -2,7 +2,7 @@ start 192.168.42.2
 end 192.168.42.20
 interface wlan0
 remaining yes
-opt dns 8.8.8.8 4.2.2.2
+opt dns 8.8.8.8 8.8.4.4
 opt subnet 255.255.255.0
 opt router 192.168.42.1
 opt lease 864000


### PR DESCRIPTION
`4.2.2.2`, whilst publicly acessible, is not officially a public DNS server. There's no obligation or guarantee of service.

This patch replaces it with `8.8.4.4`, Google's other public DNS server.
